### PR TITLE
Reformatted SoftSPI initializations

### DIFF
--- a/examples/T-DISPLAY/time_trial.py
+++ b/examples/T-DISPLAY/time_trial.py
@@ -20,13 +20,7 @@ import vga1_8x16 as font
 def main():
 
     tft = st7789.ST7789(
-        SoftSPI(
-            2,
-            baudrate=30000000,
-            polarity=1,
-            phase=1,
-            sck=Pin(18),
-            mosi=Pin(19)),
+        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_fonts.py
+++ b/examples/T-DISPLAY/ttgo_fonts.py
@@ -19,7 +19,7 @@ import vga1_bold_16x32 as font4
 
 def main():
     tft = st7789.ST7789(
-        SoftSPI(2, baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19)),
+        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_hello.py
+++ b/examples/T-DISPLAY/ttgo_hello.py
@@ -16,7 +16,7 @@ import vga1_bold_16x32 as font
 
 def main():
     tft = st7789.ST7789(
-        SoftSPI(2, baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19)),
+        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_hershey.py
+++ b/examples/T-DISPLAY/ttgo_hershey.py
@@ -65,13 +65,7 @@ def main():
     '''
     # configure display
     tft = st7789.ST7789(
-        SoftSPI(
-            2,
-            baudrate=30000000,
-            polarity=1,
-            phase=1,
-            sck=Pin(18),
-            mosi=Pin(19)),
+        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_scroll.py
+++ b/examples/T-DISPLAY/ttgo_scroll.py
@@ -30,13 +30,7 @@ def cycle(p):
 
 def main():
     tft = st7789.ST7789(
-        SoftSPI(
-            2,
-            baudrate=30000000,
-            polarity=1,
-            phase=1,
-            sck=Pin(18),
-            mosi=Pin(19)),
+        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
         135,
         240,
         reset=Pin(23, Pin.OUT),


### PR DESCRIPTION
Fixes SoftSPI calls which were previously formatted as hardware SPI.

The examples are fully working. But please see #19 about the issue with miso declarations. These calls should be possible without declaring that pin since the screen doesn't use it.