### PR TITLE
Use hardware spi

### DIFF
--- a/examples/T-DISPLAY/time_trial.py
+++ b/examples/T-DISPLAY/time_trial.py
@@ -9,7 +9,7 @@ ttgo_hello.py
 """
 
 import random
-from machine import Pin, SoftSPI
+from machine import Pin, SPI
 import st7789 as st7789
 import time
 import utime
@@ -20,7 +20,7 @@ import vga1_8x16 as font
 def main():
 
     tft = st7789.ST7789(
-        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
+        SPI(2, baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_fonts.py
+++ b/examples/T-DISPLAY/ttgo_fonts.py
@@ -8,7 +8,7 @@ ttgo_fonts.py
 """
 import utime
 import random
-from machine import Pin, SoftSPI
+from machine import Pin, SPI
 import st7789
 
 import vga1_8x8 as font1
@@ -19,7 +19,7 @@ import vga1_bold_16x32 as font4
 
 def main():
     tft = st7789.ST7789(
-        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
+        SPI(2, baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_hello.py
+++ b/examples/T-DISPLAY/ttgo_hello.py
@@ -8,7 +8,7 @@ ttgo_hello.py
 
 """
 import random
-from machine import Pin, SoftSPI
+from machine import Pin, SPI
 import st7789
 
 import vga1_bold_16x32 as font
@@ -16,7 +16,7 @@ import vga1_bold_16x32 as font
 
 def main():
     tft = st7789.ST7789(
-        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
+        SPI(2, baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_hershey.py
+++ b/examples/T-DISPLAY/ttgo_hershey.py
@@ -9,7 +9,7 @@ ttgo_hershey.py
 import utime
 import random
 import sys
-from machine import Pin, SoftSPI
+from machine import Pin, SPI
 import st7789
 
 # Load several frozen fonts from flash
@@ -65,7 +65,7 @@ def main():
     '''
     # configure display
     tft = st7789.ST7789(
-        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
+        SPI(2, baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19)),
         135,
         240,
         reset=Pin(23, Pin.OUT),

--- a/examples/T-DISPLAY/ttgo_scroll.py
+++ b/examples/T-DISPLAY/ttgo_scroll.py
@@ -9,7 +9,7 @@ ttgo_scroll.py
 """
 import utime
 import random
-from machine import Pin, SoftSPI
+from machine import Pin, SPI
 import st7789
 
 import vga1_bold_16x16 as font
@@ -30,7 +30,7 @@ def cycle(p):
 
 def main():
     tft = st7789.ST7789(
-        SoftSPI(baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19), miso=Pin(21)),
+        SPI(2, baudrate=30000000, polarity=1, phase=1, sck=Pin(18), mosi=Pin(19)),
         135,
         240,
         reset=Pin(23, Pin.OUT),


### PR DESCRIPTION
From further testing I found the previous implementation had the correct parameters for hardware spi but was calling SoftSPI. This pull request moves to hardware:
* Much faster performance
* Doesn't waste an IO pin for MISO which the screen doesn't have

Sorry I didn't discover this before sending you #20 