### PR TITLE
print the JRESULT value returned by jd_prepare function

### DIFF
--- a/st7789/jpg/tjpgd565.c
+++ b/st7789/jpg/tjpgd565.c
@@ -950,3 +950,20 @@ JRESULT jd_decomp (
 
 	return rc;
 }
+/*-----------------------------------------------------------------------*/
+/*----------------------Parse the error codes----------------------------*/
+/*-----------------------------------------------------------------------*/
+const char* jresult_to_string(JRESULT result) {
+    switch (result) {
+        case JDR_OK:    return "Succeeded";
+        case JDR_INTR:  return "Interrupted by output function";
+        case JDR_INP:   return "Device error or wrong termination of input stream";
+        case JDR_MEM1:  return "Insufficient memory pool for the image";
+        case JDR_MEM2:  return "Insufficient stream input buffer";
+        case JDR_PAR:   return "Parameter error";
+        case JDR_FMT1:  return "Data format error (may be damaged data)";
+        case JDR_FMT2:  return "Right format but not supported";
+        case JDR_FMT3:  return "Not supported JPEG standard";
+        default:        return "Unknown error";
+    }
+}

--- a/st7789/jpg/tjpgd565.h
+++ b/st7789/jpg/tjpgd565.h
@@ -72,7 +72,7 @@ struct JDEC {
 /* TJpgDec API functions */
 JRESULT jd_prepare (JDEC* jd, unsigned int (*infunc)(JDEC*,uint8_t*,unsigned int), void* pool, unsigned int sz_pool, void* dev);
 JRESULT jd_decomp (JDEC* jd, int (*outfunc)(JDEC*,void*,JRECT*), uint8_t scale);
-
+const char* jresult_to_string(JRESULT result);
 
 #ifdef __cplusplus
 }

--- a/st7789/st7789.c
+++ b/st7789/st7789.c
@@ -1667,12 +1667,13 @@ static mp_obj_t st7789_ST7789_jpg(size_t n_args, const mp_obj_t *args) {
 
     JRESULT res;                                // Result code of TJpgDec API
     JDEC jdec;                                  // Decompression object
-    self->work = (void *)m_malloc(3100);        // Pointer to the work area
+    self->work = (void *)m_malloc(8192);        // Pointer to the work area
     size_t bufsize;
 
     if (input_func && (devid.fp || devid.data)) {
         // Prepare to decompress
-        res = jd_prepare(&jdec, input_func, self->work, 3100, &devid);
+        res = jd_prepare(&jdec, input_func, self->work, 8192, &devid);
+        mp_printf(&mp_plat_print, "Result: %s\r\n", jresult_to_string(res));
         if (res == JDR_OK) {
             // Initialize output device
             if (mode == JPG_MODE_FAST) {
@@ -1801,7 +1802,7 @@ static mp_obj_t st7789_ST7789_jpg_decode(size_t n_args, const mp_obj_t *args) {
             height = mp_obj_get_int(args[5]);
         }
 
-        self->work = (void *)m_malloc(3100);          // Pointer to the work area
+        self->work = (void *)m_malloc(8192);          // Pointer to the work area
 
         JRESULT res;          // Result code of TJpgDec API
         JDEC jdec;            // Decompression object
@@ -1809,7 +1810,7 @@ static mp_obj_t st7789_ST7789_jpg_decode(size_t n_args, const mp_obj_t *args) {
 
         if (input_func && (devid.fp || devid.data)) {
             // Prepare to decompress
-            res = jd_prepare(&jdec, input_func, self->work, 3100, &devid);
+            res = jd_prepare(&jdec, input_func, self->work, 8192, &devid);
             if (res == JDR_OK) {
                 if (n_args < 6) {
                     x = 0;


### PR DESCRIPTION
Add helper to know the result of the type JRESULT returned by the function jd_prepare. This was helpful to identify the reason why the jd_prepare was failing with the string being printed on the console _**"jpg prepare failed"**_

Also increased the buffer size to load and test large size images on ESP32